### PR TITLE
Adds Docker Support

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,7 +13,7 @@ on:
   release:
     types: [published]
   push:
-      branches: [ "main" ]
+      branches: [ "main", "master" ]
       # tags: [ 'v*.*.*' ]
 
 jobs:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,51 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+  push:
+      branches: [ "main" ]
+      # tags: [ 'v*.*.*' ]
+
+jobs:
+  push_to_registry:
+    name: Push Docker images to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      # attestations: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for ghost-static-site-generator Image
+        id: ghost-static-site-generator
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{github.actor}}/ghost-static-site-generator
+      
+      - name: Build and push ghost-static-site-generator Docker image
+        id: build-push-ghost-static-site-generator
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.ghost-static-site-generator.outputs.tags }}
+          labels: ${{ steps.ghost-static-site-generator.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -38,7 +38,7 @@ jobs:
         id: ghost-static-site-generator
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{github.actor}}/ghost-static-site-generator
+          images: ${{ secrets.DOCKER_USERNAME }}/ghost-static-site-generator
       
       - name: Build and push ghost-static-site-generator Docker image
         id: build-push-ghost-static-site-generator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:alpine
+
+# install wget 
+RUN apk update && apk add --no-cache wget && \
+    mkdir -p /app/node_modules
+
+# copy code and install node deps
+WORKDIR /home/node/app
+COPY package*.json ./
+COPY --chown=node:node . .
+RUN npm install
+
+# set workdir to /data
+WORKDIR /data
+
+# describe volume
+VOLUME "/data"
+
+# set entrypoint to script
+ENTRYPOINT  [ "node", "/home/node/app/src/index.js" ]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,34 @@ $ cd ghost-static-site-generator
 $ npm install
 ```
 
+### Docker
+To install docker see: [https://docs.docker.com/engine/install/](https://docs.docker.com/engine/install/)
+1. [Optional Build] Clone this repository
+```bash
+$ git clone https://github.com/itsignacioportal/ghost-static-site-generator/
+$ cd ghost-static-site-generator
+$ docker build -t ghost-static-site-generator:latest .
+```
+
+2. Run image with volume mounted.
+#### Network config
+    - to access localhost add `--network host` 
+    - to access another container
+        1. `docker network create --attachable ghost-scrape`
+        2. `docker network connect ghost-scrape <YOUR GHOST CONTAINER>`
+        3. add `--network ghost-scrape` to your command
+
+```bash
+# Make output dir
+$ mkdir ./data
+
+# Run and remove container when done
+$ docker run --rm -it \
+    -v ./data:/data \
+    SimonM0/ghost-static-site-generator:latest \
+    --domain http://www.myhiddenserver.com:4538 \
+    --productionDomain http://www.myblog.com
+```
 
 ## Usages
 By default the tool will default to `http://localhost:2368` for the domain and generate a folder called `static` in the directory that you run the tool in.


### PR DESCRIPTION
# Docker Support

This adds a docker image, updates readme with examples and adds github workflows to push to docker.

### Building the image manually
1. [Optional Build] Clone this repository
```bash
$ git clone https://github.com/itsignacioportal/ghost-static-site-generator/
$ cd ghost-static-site-generator
$ docker build -t ghost-static-site-generator:latest .
```

### Useage example
```bash
# Make output dir
$ mkdir ./data

# Run and remove container when done
$ docker run --rm -it \
    -v ./data:/data \
    SimonM0/ghost-static-site-generator:latest \
    --domain http://www.myhiddenserver.com:4538 \
    --productionDomain http://www.myblog.com
```


### Setup Workflow
1. Make a [dockerhub access token](https://hub.docker.com/settings/security)
2. Add these 2 [secrets](https://github.com/MaxwellDPS/ghost-static-site-generator/settings/secrets/actions/new) 
    - `DOCKER_USERNAME`
    - `DOCKER_PASSWORD` ([dockerhub access token](https://hub.docker.com/settings/security))

[See example](https://github.com/MaxwellDPS/ghost-static-site-generator/actions/runs/9239282985/job/25418271720)

To install docker see: [https://docs.docker.com/engine/install/](https://docs.docker.com/engine/install/)